### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/p5quared/dorito/security/code-scanning/1](https://github.com/p5quared/dorito/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the GITHUB_TOKEN. Since the workflow only checks out code, installs dependencies, and runs tests (with no steps that require write access to the repository or pull requests), the minimal permission required is `contents: read`. This block should be added at the root level of the workflow (just after the `name` and `on` keys), so it applies to all jobs unless overridden. No changes to the steps or jobs are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
